### PR TITLE
fix(sonar): prefer `globalThis.window` over `window` and `globalThis.document` over `document`

### DIFF
--- a/src/main/ts/core/DOMBuilder.ts
+++ b/src/main/ts/core/DOMBuilder.ts
@@ -9,13 +9,13 @@ export class DOMBuilder {
     private static readonly BS_ATTRIBUTE = "bsTheme";
 
     constructor(container: HTMLElement, options: ResolvedOptions) {
-        this.root = document.querySelectorAll<HTMLElement>(options.root);
+        this.root = globalThis.document.querySelectorAll<HTMLElement>(options.root);
         this.lightColorMode = options.lightColorMode;
         this.darkColorMode = options.darkColorMode;
 
         container.innerHTML = "";
 
-        this.input = document.createElement("input") as BootstrapToggleElement;
+        this.input = globalThis.document.createElement("input") as BootstrapToggleElement;
         this.input.type = "checkbox";
 
         container.appendChild(this.input);

--- a/src/main/ts/index.ecmas.ts
+++ b/src/main/ts/index.ecmas.ts
@@ -37,7 +37,7 @@ import { Methods } from "./types/Methods";
     /**
      * Auto-initialize plugin on elements with `data-plugin="bs-darkmode-toggle"`
      */
-    if (typeof globalThis.window !== "undefined") {
+    if (globalThis.window !== undefined) {
         globalThis.window.onload = () => {
             globalThis.document
                 .querySelectorAll<HTMLElement>('[data-plugin="bs-darkmode-toggle"]')
@@ -46,7 +46,7 @@ import { Methods } from "./types/Methods";
     }
 
     // Export library if possible
-    if (typeof module !== "undefined" && module.exports) {
+    if (module !== undefined && module.exports) {
         module.exports = DarkModeToggle;
     }
 

--- a/src/main/ts/index.ecmas.ts
+++ b/src/main/ts/index.ecmas.ts
@@ -37,9 +37,9 @@ import { Methods } from "./types/Methods";
     /**
      * Auto-initialize plugin on elements with `data-plugin="bs-darkmode-toggle"`
      */
-    if (typeof window !== "undefined") {
-        window.onload = () => {
-            document
+    if (typeof globalThis.window !== "undefined") {
+        globalThis.window.onload = () => {
+            globalThis.document
                 .querySelectorAll<HTMLElement>('[data-plugin="bs-darkmode-toggle"]')
                 .forEach((el) => el.bsDarkmodeToggle());
         };

--- a/src/test/ts/core/DOMBuilder.test.ts
+++ b/src/test/ts/core/DOMBuilder.test.ts
@@ -99,7 +99,7 @@ describe("DOMBuilder", () => {
 
             builder.setState(true);
 
-            document.querySelectorAll<HTMLElement>(".root").forEach((el) => {
+            globalThis.document.querySelectorAll<HTMLElement>(".root").forEach((el) => {
                 expect(el.dataset.bsTheme).toBe("light");
             });
         });


### PR DESCRIPTION
Use "globalThis" instead of "window", "self", or "global" typescript:S7764

### Change Summary
**Indicate the type of change being made.**
- [ ] New Feature
- [ ] Bug Fix
- [X] Refactor
- [ ] Documentation

### Description
**Provide a brief description of the change.**
- For New Features or Bug Fixes, reference the related issue number.
- For other changes, provide a brief description.

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests. If removed, please explain why in additional notes.**
- [ ] Added tests
- [ ] Modified tests
- [ ] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [ ] Documentation updated

### Additional Notes
**Provide any additional information or context related to this pull request.**

---

## Pull Request Checklist
- [X] Code adheres to the project's coding style guide.
- [X] All tests are passing.
- [X] The pull request description is complete.
- [X] Documentation is updated if needed.
