### PR TITLE
feat: add custom darkmode:change event with rich detail

### DIFF
--- a/cypress/support/page-objects/TestAppPage.js
+++ b/cypress/support/page-objects/TestAppPage.js
@@ -29,15 +29,19 @@ class TestAppPage {
 
     static verifyConsoleMessage(expected) {
         if (expected) {
-            this.getConsoleOutput().should(
-                "have.text",
-                TEST_CONSTANTS.CONSOLE_FIRED_TEXT
-            );
+            this.getConsoleOutput().find("div")
+                .contains(TEST_CONSTANTS.EVENTS_CONSOLE_TEXT.container.darkmode_change)
+                .should("exist");
+
+            this.getConsoleOutput().find("div")
+                .contains(TEST_CONSTANTS.EVENTS_CONSOLE_TEXT.element.change)
+                .should("exist");
+
+            this.getConsoleOutput().find("div")
+                .contains(TEST_CONSTANTS.EVENTS_CONSOLE_TEXT.element.darkmode_change)
+                .should("exist");
         } else {
-            this.getConsoleOutput().should(
-                "not.have.text",
-                TEST_CONSTANTS.CONSOLE_FIRED_TEXT
-            );
+            this.getConsoleOutput().find("div").should("not.exist");
         }
     }
 

--- a/docs/src/js/components/documentation/Events.js
+++ b/docs/src/js/components/documentation/Events.js
@@ -1,11 +1,13 @@
 import DocSection from "./DocSection";
 import EventPropagation from "./events/EventPropagation";
+import CustomEvents from "./events/CustomEvents";
 import SilencedActions from "./events/SilencedActions";
 
 class Events extends DocSection {
     static build() {
         return super.build("events", "Events", [
             EventPropagation.build(),
+            CustomEvents.build(),
             SilencedActions.build(),
         ]);
     }

--- a/docs/src/js/components/documentation/events/CustomEvents.js
+++ b/docs/src/js/components/documentation/events/CustomEvents.js
@@ -1,0 +1,144 @@
+import Console from "../../Console";
+import DocArticle from "../DocArticle";
+
+class CustomEvents extends DocArticle {
+    static #events = [
+        {
+            name: "darkmode:change",
+            action: "toggle",
+        },
+    ];
+
+    static build() {
+        const root = document.createElement("div");
+        root.id = "event-custom-container";
+        root.className = "p-3 bg-body border";
+
+        const toggle = document.createElement("div");
+        toggle.dataset.plugin = "bs-darkmode-toggle";
+        toggle.id = "event-custom-toggle";
+        toggle.dataset.root = "#event-custom-container";
+        root.appendChild(toggle);
+
+        const console = new Console();
+
+        CustomEvents.#events.forEach((event) => {
+            toggle.addEventListener(event.name, (e) => {
+                e.stopPropagation();
+                const detail  = {isLight: e.detail.isLight, theme: e.detail.theme, element: "<...>(HTML Element)", roots: ["<...>(HTML Element)"]};
+                console.log({
+                    mode: "append",
+                    data: `Event ${event.name} fired on control. Event detail: ${JSON.stringify(detail, null, 2)}`,
+                });
+            });
+
+            root.addEventListener(event.name, (e) => {
+                e.stopPropagation();
+                const detail  = {isLight: e.detail.isLight, theme: e.detail.theme, element: "<...>(HTML Element)", roots: ["<...>(HTML Element)"]};
+                console.log({
+                    mode: "append",
+                    data: `Event ${event.name} fired on root. Event detail: ${JSON.stringify(detail, null, 2)}`,
+                });
+            });
+        });
+
+        return super.build({
+            title: "Custom Events",
+            description: CustomEvents.#description(toggle),
+            codeBlock: {
+                language: "html",
+                code: `<div id="event-custom-container" class="p-3 bg-body border">
+  <div
+    data-plugin="bs-darkmode-toggle"
+    id="event-custom-toggle"
+    data-root="#event-custom-container"></div>
+</div>
+<script>
+    document
+        .getElementById('event-custom-toggle')
+        .addEventListener('darkmode:change',(e)=>{
+            e.stopPropagation();
+            console.log(e);
+        });
+    document
+        .getElementById('event-custom-container')
+        .addEventListener('darkmode:change',(e)=>{
+            e.stopPropagation();
+            console.log(e);
+        });
+</script>`,
+            },
+            example: [root, console.htmlElement],
+            versionPill: { action: "SINCE", version: "1.1.0" },
+        });
+    }
+
+    static #description(toggle) {
+        const description = document.createElement("div");
+
+        const paragraph = document.createElement("p");
+        paragraph.innerHTML =
+            "Bootstrap Darkmode Toggle emit custom events when its state is changed from the control and for each root element. The events details contain the current state and the element information. The following custom events are available:";
+        description.append(paragraph, CustomEvents.#table(toggle));
+
+        return description;
+    }
+
+    static #table(toggle) {
+        const table = document.createElement("table");
+        table.className = "table table-striped table-condensed";
+        const caption = document.createElement("caption");
+        caption.textContent = "Custom events";
+        table.append(
+            caption,
+            CustomEvents.#thead(),
+            CustomEvents.#tbody(toggle)
+        );
+
+        return table;
+    }
+
+    static #thead() {
+        const thead = document.createElement("thead");
+        const tr = document.createElement("tr");
+        tr.append(
+            ...["Event", "Example", "Launch"].map((label) => {
+                const th = document.createElement("th");
+                th.textContent = label;
+                return th;
+            })
+        );
+        thead.append(tr);
+        return thead;
+    }
+
+    static #tbody(toggle) {
+        const tbody = document.createElement("tbody");
+
+        const trs = CustomEvents.#events.map(({ name, action }) => {
+            const td1 = document.createElement("td");
+            td1.innerHTML = `<em>${name}</em>`;
+
+            const td2 = document.createElement("td");
+            td2.innerHTML = `<code>myToggle.addEventListener("${name}", (e)=>{...})</code>`;
+
+            const td3 = document.createElement("td");
+            const defaultBtn = document.createElement("button");
+            defaultBtn.className = "btn btn-outline-dark btn-sm w-100";
+            defaultBtn.textContent = action;
+            defaultBtn.onclick = () => {
+                toggle.bsDarkmodeToggle(action, false);
+            };
+            td3.append(defaultBtn);
+
+            const tr = document.createElement("tr");
+            tr.append(td1, td2, td3);
+            return tr;
+        });
+
+        tbody.append(...trs);
+        return tbody;
+    }
+}
+
+export default CustomEvents;

--- a/src/main/ts/DarkModeToggle.ts
+++ b/src/main/ts/DarkModeToggle.ts
@@ -5,6 +5,7 @@ import { DomManager } from "./core/dom/DomManager";
 import { ResolvedOptions, StorageType } from "./core/OptionResolver.types";
 import { ActionType } from "./core/StateReducer.types";
 import { ColorModes } from "./types/ColorModes";
+import { EventManager } from "./core/events/EventManager";
 
 export class DarkModeToggle {
     private readonly element: HTMLElement;
@@ -12,6 +13,7 @@ export class DarkModeToggle {
     private readonly state: StateReducer;
     private readonly storage: StorageManager;
     private readonly dom: DomManager;
+    private readonly eventManager: EventManager;
 
     constructor(element: HTMLElement, opts = {}) {
         this.element = element;
@@ -19,12 +21,12 @@ export class DarkModeToggle {
         this.options = OptionResolver.resolve(element, opts);
         this.state = new StateReducer(this.options.state, this.options.lightColorMode, this.options.darkColorMode);
         this.storage = new StorageManager(this.options.storage);
+        this.eventManager = new EventManager(this.element, this.options.root);
 
         this.applyPreferredScheme();
 
         this.dom = new DomManager(this.element, this.options, (e) => {
-            this.toggle(true);
-            this.persistTheme();
+            this.toggle();
             e.preventDefault();
         });
 
@@ -65,10 +67,16 @@ export class DarkModeToggle {
         this.persistTheme();
     }
 
+    /**
+     * Triggers the events if silent is false.
+     * The events are triggered with the current state of the dark mode toggle.
+     * Delegates dispatch events to the event manager.
+     * @private
+     * @param {boolean} silent - Whether to trigger the event.
+     */
     private trigger(silent: boolean) {
-        if (!silent) {
-            this.element.dispatchEvent(new Event("change", { bubbles: true }));
-        }
+        if (silent) return;
+        this.eventManager.dispatch(this.state.get());
     }
 
     /**

--- a/src/main/ts/core/events/DarkModeToggleEvent.ts
+++ b/src/main/ts/core/events/DarkModeToggleEvent.ts
@@ -1,0 +1,10 @@
+import { CustomEventTypes, DarkModeToggleEventDetail } from "./Events.types";
+
+export class DarkModeToggleEvent extends CustomEvent<DarkModeToggleEventDetail> {
+    constructor(type: CustomEventTypes, detail: DarkModeToggleEventDetail) {
+        super(type, {
+            bubbles: true,
+            detail,
+        });
+    }
+}

--- a/src/main/ts/core/events/EventManager.ts
+++ b/src/main/ts/core/events/EventManager.ts
@@ -1,0 +1,60 @@
+import { DarkModeState } from "../StateReducer.types";
+import { DarkModeToggleEvent } from "./DarkModeToggleEvent";
+import { CustomEventTypes, DarkModeToggleEventDetail, LegacyEventTypes } from "./Events.types";
+
+export class EventManager {
+    private readonly element: HTMLElement;
+    private readonly roots: HTMLElement[];
+
+    constructor(element: HTMLElement, rootSelector: string) {
+        this.element = element;
+        this.roots = Array.from(
+            globalThis.document.querySelectorAll<HTMLElement>(
+                rootSelector
+            )
+        );
+    }
+
+    /**
+     * Dispatches the darkmode:change event on source and all root elements
+     * @param state - The current state of the darkmode toggle
+     */
+    dispatch(state: DarkModeState) {
+        EventManager.dispatchChangeEvent(this.element);
+        EventManager.dispatchDarkModeChangeEvent(state.isLight, state.theme, this.element, this.roots);
+    }
+
+    /**
+     * Dispatches the standard change event for backward compatibility
+     * @static
+     * @param source - The source element that triggered the change
+     */
+    private static dispatchChangeEvent(source: HTMLElement): void {
+        source.dispatchEvent(
+            new Event(LegacyEventTypes.CHANGE, { bubbles: true })
+        );
+    }
+
+    /**
+     * Dispatches the darkmode:change event on source and all root elements
+     * @static
+     * @param isLight - Whether the current state is light or dark
+     * @param theme - The current theme
+     * @param source - The source element that triggered the change
+     * @param roots - All root elements where the theme should be updated
+     */
+    private static dispatchDarkModeChangeEvent(
+        isLight: boolean,
+        theme: string,
+        source: HTMLElement,
+        roots: HTMLElement[]
+    ): void {
+        const eventDetail: DarkModeToggleEventDetail = { isLight, theme, source, roots };
+
+        source.dispatchEvent(new DarkModeToggleEvent(CustomEventTypes.CHANGE, eventDetail));
+
+        roots.forEach((root) => {
+            root.dispatchEvent(new DarkModeToggleEvent(CustomEventTypes.CHANGE, eventDetail));
+        });
+    }
+}

--- a/src/main/ts/core/events/Events.types.ts
+++ b/src/main/ts/core/events/Events.types.ts
@@ -1,0 +1,16 @@
+export interface DarkModeToggleEventDetail {
+  isLight: boolean;
+  theme: string;
+  source: HTMLElement;
+  roots: HTMLElement[];
+}
+
+export enum CustomEventTypes{
+    CHANGE = "darkmode:change",
+}
+
+export enum LegacyEventTypes{
+    CHANGE = "change",
+}
+
+export type EventTypes = CustomEventTypes | LegacyEventTypes;

--- a/src/main/ts/types/Events.ts
+++ b/src/main/ts/types/Events.ts
@@ -1,5 +1,0 @@
-enum Events{
-    CHANGE = "change",
-}
-
-export default Events;

--- a/src/test/ts/DarkModeToggle.test.ts
+++ b/src/test/ts/DarkModeToggle.test.ts
@@ -58,6 +58,15 @@ jest.mock("../../main/ts/core/storage/StorageManager", () => {
     };
 });
 
+const dispatchMock = jest.fn();
+jest.mock("../../main/ts/core/events/EventManager", () => {
+    return {
+        EventManager: jest.fn().mockImplementation(() => ({
+            dispatch: dispatchMock,
+        })),
+    };
+});
+
 const matchMediaMock = jest.fn();
 
 function setMatchMedia(colorMode: ColorModes) {
@@ -98,112 +107,96 @@ describe("DarkModeToggle", () => {
 
     describe("toggle(silent = false)", () => {
         it("should toggle and trigger event", () => {
-            const dispatchSpy = jest.spyOn(element, "dispatchEvent");
-
             const instance = new DarkModeToggle(element);
 
             instance.toggle();
 
             expect(doMock).toHaveBeenCalledWith(ActionType.TOGGLE);
             expect(setStateMock).toHaveBeenCalledTimes(2);
-            expect(dispatchSpy).toHaveBeenCalledTimes(1);
+            expect(dispatchMock).toHaveBeenCalledTimes(1);
         });
 
         it("should NOT toggle if reducer returns false", () => {
             doMock.mockReturnValue(false);
-            const dispatchSpy = jest.spyOn(element, "dispatchEvent");
-
             const instance = new DarkModeToggle(element);
 
             instance.toggle();
 
             expect(setStateMock).toHaveBeenCalledTimes(1);
-            expect(dispatchSpy).not.toHaveBeenCalled();
+            expect(dispatchMock).not.toHaveBeenCalled();
         });
 
         it("should not trigger event when silent", () => {
-            const dispatchSpy = jest.spyOn(element, "dispatchEvent");
-
             const instance = new DarkModeToggle(element);
 
             instance.toggle(true);
 
             expect(setStateMock).toHaveBeenCalledTimes(2);
-            expect(dispatchSpy).not.toHaveBeenCalled();
+            expect(dispatchMock).not.toHaveBeenCalled();
         });
     });
 
     describe("light(silent = false)", () => {
         it("should set light and trigger event", () => {
-            const dispatchSpy = jest.spyOn(element, "dispatchEvent");
-
             const instance = new DarkModeToggle(element);
 
             instance.light();
 
             expect(doMock).toHaveBeenCalledWith(ActionType.LIGHT);
             expect(setStateMock).toHaveBeenCalledTimes(2);
-            expect(dispatchSpy).toHaveBeenCalledTimes(1);
+            expect(dispatchMock).toHaveBeenCalledTimes(1);
         });
 
         it("should NOT set light if reducer returns false", () => {
             doMock.mockReturnValue(false);
-            const dispatchSpy = jest.spyOn(element, "dispatchEvent");
 
             const instance = new DarkModeToggle(element);
 
             instance.light();
 
             expect(setStateMock).toHaveBeenCalledTimes(1);
-            expect(dispatchSpy).not.toHaveBeenCalled();
+            expect(dispatchMock).not.toHaveBeenCalled();
         });
 
         it("should not trigger event when silent", () => {
-            const dispatchSpy = jest.spyOn(element, "dispatchEvent");
-
             const instance = new DarkModeToggle(element);
 
             instance.light(true);
 
             expect(setStateMock).toHaveBeenCalledTimes(2);
-            expect(dispatchSpy).not.toHaveBeenCalled();
+            expect(dispatchMock).not.toHaveBeenCalled();
         });
     });
 
     describe("dark(silent = false)", () => {
         it("should set dark and trigger event", () => {
-            const dispatchSpy = jest.spyOn(element, "dispatchEvent");
-
             const instance = new DarkModeToggle(element);
 
             instance.dark();
 
             expect(doMock).toHaveBeenCalledWith(ActionType.DARK);
             expect(setStateMock).toHaveBeenCalledTimes(2);
-            expect(dispatchSpy).toHaveBeenCalledTimes(1);
+            expect(dispatchMock).toHaveBeenCalledTimes(1);
         });
 
         it("should NOT set dark if reducer returns false", () => {
             doMock.mockReturnValue(false);
-            const dispatchSpy = jest.spyOn(element, "dispatchEvent");
 
             const instance = new DarkModeToggle(element);
 
             instance.dark();
 
             expect(setStateMock).toHaveBeenCalledTimes(1);
-            expect(dispatchSpy).not.toHaveBeenCalled();
+            expect(dispatchMock).not.toHaveBeenCalled();
         });
 
         it("should not trigger event when silent", () => {
-            const dispatchSpy = jest.spyOn(element, "dispatchEvent");
-
             const instance = new DarkModeToggle(element);
 
             instance.dark(true);
 
             expect(setStateMock).toHaveBeenCalledTimes(2);
-            expect(dispatchSpy).not.toHaveBeenCalled();
+            expect(dispatchMock).not.toHaveBeenCalled();
         });
     });
   

--- a/src/test/ts/core/events/EventManager.test.ts
+++ b/src/test/ts/core/events/EventManager.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/// <reference types="jest" />
+import { EventManager } from "../../../../main/ts/core/events/EventManager";
+import { CustomEventTypes, LegacyEventTypes } from "../../../../main/ts/core/events/Events.types";
+
+let element: HTMLElement;
+let root: HTMLElement;
+
+const elementEventDispatchMock = jest.fn();
+const rootEventDispatchMock = jest.fn();
+
+function createEventManager():EventManager{
+    return new EventManager(element, ".root");
+}
+
+describe("DomManager", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        document.body.innerHTML = "";
+
+        element = document.createElement("div");
+        document.body.appendChild(element);
+        jest.spyOn(element, "dispatchEvent").mockImplementation(elementEventDispatchMock);
+
+        root = document.createElement("div");
+        root.className = "root";
+        document.body.appendChild(root);
+        jest.spyOn(root, "dispatchEvent").mockImplementation(rootEventDispatchMock);
+    });
+
+    describe("constructor", () => {
+        it("should get all roots", () => {
+            const root2 = document.createElement("div");
+            root2.className = "root";
+            document.body.appendChild(root2);
+
+            const instance = createEventManager();
+            expect((instance as any).roots).toStrictEqual([root, root2]);
+        });
+    });
+
+    describe("dispatch(state)", () => {
+        it("should dispatch all events", () => {
+            const instance = createEventManager();
+            instance.dispatch({isLight: true, theme: "light"});
+
+            expect(elementEventDispatchMock).toHaveBeenCalledTimes(2);
+            expect(rootEventDispatchMock).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("dispatchChangeEvent(source)", () => {
+        it("should dispatch change event from source", () => {
+            (EventManager as any).dispatchChangeEvent(element);
+
+            const expectedEvent = { type: LegacyEventTypes.CHANGE, bubbles: true };
+
+            expect(elementEventDispatchMock).toHaveBeenCalledTimes(1);
+            expect(elementEventDispatchMock).toHaveBeenCalledWith(expect.any(Event));
+            expect(elementEventDispatchMock).toHaveBeenCalledWith(expect.objectContaining(expectedEvent));
+        });
+    });
+
+    describe("dispatchDarkModeChangeEvent(isLight, theme, source, roots)", () => {
+        it("should dispatch change event from source", () => {
+            (EventManager as any).dispatchDarkModeChangeEvent(true, "light", element, [root]);
+
+            const expectedEvent = { type: CustomEventTypes.CHANGE, detail: { isLight: true, theme: "light", source: element, roots: [root] }, bubbles: true };
+
+            expect(elementEventDispatchMock).toHaveBeenCalledTimes(1);
+            expect(elementEventDispatchMock).toHaveBeenCalledWith(expect.any(Event));
+            expect(elementEventDispatchMock).toHaveBeenCalledWith(expect.objectContaining(expectedEvent));
+
+            expect(rootEventDispatchMock).toHaveBeenCalledTimes(1);
+            expect(rootEventDispatchMock).toHaveBeenCalledWith(expect.any(Event));
+            expect(rootEventDispatchMock).toHaveBeenCalledWith(expect.objectContaining(expectedEvent));
+        });
+    });
+});

--- a/test/common/constants.js
+++ b/test/common/constants.js
@@ -9,8 +9,16 @@ export const TEST_CONSTANTS = Object.freeze({
     TEST_CONSOLE_CLASS: "console",
     TEST_CONSOLE_SELECTOR: ".console",
 
-    // Messages
-    CONSOLE_FIRED_TEXT: "Change event fired!",
+    // Events
+    EVENTS_CONSOLE_TEXT:{
+        element:{
+            change: "change event fired on element!",
+            darkmode_change: "darkmode:change event fired on element!"
+        },
+        container:{
+            darkmode_change: "darkmode:change event fired on container!"
+        }
+    },
 
     // Plugin defaults
     DEFAULTS: {

--- a/test/loaders/MethodsLoader.js
+++ b/test/loaders/MethodsLoader.js
@@ -31,7 +31,7 @@ export class MethodsLoader extends BaseLoader {
 
         $container.append($row);
         this.appendToMain("Case Methods", $container);
-        this.#bindEvents($element, $console);
+        this.#bindEvents($element, $container, $console);
     }
 
     #getButtons($element) {
@@ -124,9 +124,20 @@ export class MethodsLoader extends BaseLoader {
         return $group;
     }
 
-    #bindEvents($element, $console) {
-        $element.on("change", () => {
-            $console.text(TEST_CONSTANTS.CONSOLE_FIRED_TEXT);
+    #bindEvents($element, $container, $console) {
+        $element.on("change", (e) => {
+            e.stopPropagation();
+            $console.append(`<div>${TEST_CONSTANTS.EVENTS_CONSOLE_TEXT.element.change}</div>`);
+        });
+
+        $element.on("darkmode:change", (e) => {
+            e.stopPropagation();
+            $console.append(`<div>${TEST_CONSTANTS.EVENTS_CONSOLE_TEXT.element.darkmode_change}</div>`);
+        });
+
+        $container.on("darkmode:change", (e) => {
+            e.stopPropagation();
+            $console.append(`<div>${TEST_CONSTANTS.EVENTS_CONSOLE_TEXT.container.darkmode_change}</div>`);
         });
     }
 }


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation

### Description
**Provide a brief description of the change.**
- Implements #63 - Custom Events (darkmode:change)
- Adds new `darkmode:change` event dispatched on theme changes
- Event detail includes `isLight`, `theme`, `source`, and `roots` properties
- Events bubble through DOM and dispatch on both toggle element and all root elements
- Preserves backward compatibility with existing `change` event
- `silent` parameter now suppresses all events consistently

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests.**
- [x] Added tests (EventManager.test.ts with full coverage)
- [x] Modified tests (DarkModeToggle.test.ts to use EventManager mock)
- [x] Fixed tests (E2E tests updated for multiple event types)
- [ ] Removed tests (none)

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [x] Documentation updated
  - New "Custom Events" documentation page with interactive example
  - Code examples for listening to `darkmode:change` on both control and root elements
  - Version pill marked "SINCE 1.1.0"

### Additional Notes
**Provide any additional information or context.**
- Root elements are cached on EventManager initialization for better performance
- Each root receives its own event instance (no event reuse across targets)
- Legacy `change` event continues to be dispatched alongside the new custom event
- Full TypeScript support with `DarkModeToggleEventDetail` interface exported

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide.
- [x] All tests are passing (56/56 unit tests, 7/7 E2E specs).
- [x] The pull request description is complete.
- [x] Documentation is updated if needed.