### PR TITLE
refactor: replace static root selection with dynamic runtime queries

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,6 +3,7 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
     allowCypressEnv: false,
     e2e: {
+        screenshotOnRunFailure: false,
         setupNodeEvents(on, config) {
         // implement node event listeners here
         },

--- a/cypress/support/page-objects/TestAppPage.js
+++ b/cypress/support/page-objects/TestAppPage.js
@@ -12,7 +12,6 @@ class TestAppPage {
 
         cy.clearCookie("bs-darkmode-toggle-color-scheme");
         cy.get(`button#${testId}`).click();
-        cy.wait(500);
     }
 
     static getTestContainers() {

--- a/src/main/ts/DarkModeToggle.ts
+++ b/src/main/ts/DarkModeToggle.ts
@@ -21,14 +21,17 @@ export class DarkModeToggle {
         this.options = OptionResolver.resolve(element, opts);
         this.state = new StateReducer(this.options.state, this.options.lightColorMode, this.options.darkColorMode);
         this.storage = new StorageManager(this.options.storage);
-        this.eventManager = new EventManager(this.element, this.options.root);
 
         this.applyPreferredScheme();
 
-        this.dom = new DomManager(this.element, this.options, (e) => {
+        const dom = new DomManager(this.element, this.options, (e) => {
             this.toggle();
             e.preventDefault();
         });
+
+        this.dom = dom;
+
+        this.eventManager = new EventManager(this.element, () => dom.roots);
 
         this.element._bsDarkmodeToggle = this;
 

--- a/src/main/ts/core/dom/AbstractLayout.ts
+++ b/src/main/ts/core/dom/AbstractLayout.ts
@@ -2,7 +2,7 @@ import { ResolvedOptions } from "../OptionResolver.types";
 import { DarkModeState } from "../StateReducer.types";
 
 export abstract class AbstractLayout {
-    protected readonly root: NodeListOf<HTMLElement>;
+    protected readonly rootSelector: string;
     protected readonly lightLabel: string;
     protected readonly darkLabel: string;
     protected readonly style: string;
@@ -15,13 +15,23 @@ export abstract class AbstractLayout {
      * @param {ResolvedOptions} options - The resolved options to apply to the layout.
      */
     constructor(container: HTMLElement, options: ResolvedOptions) {
-        this.root = globalThis.document.querySelectorAll<HTMLElement>(options.root);
+        this.rootSelector = options.root;
         this.lightLabel = options.lightLabel;
         this.darkLabel = options.darkLabel;
         this.style = options.style;
 
         container.innerHTML = "";
         this.createControl(container);
+    }
+
+    /**
+     * Gets the root elements in the layout.
+     * 
+     * Implementation note: roots are not cached to avoid re-querying the DOM because roots can change (added or removed) during runtime.
+     * @returns {HTMLElement[]} The root elements in the layout.
+     */
+    public get roots(): HTMLElement[] {
+        return Array.from(globalThis.document.querySelectorAll<HTMLElement>(this.rootSelector));
     }
 
     /**
@@ -40,7 +50,7 @@ export abstract class AbstractLayout {
      */
     public setState(state: DarkModeState): void{
         this.updateControlState(state);
-        this.root.forEach((el) => {
+        this.roots.forEach((el) => {
             el.dataset[AbstractLayout.BS_ATTRIBUTE] = state.theme;
         });
     }

--- a/src/main/ts/core/dom/DomManager.ts
+++ b/src/main/ts/core/dom/DomManager.ts
@@ -40,4 +40,12 @@ export class DomManager{
     public setState(state: DarkModeState): void{
         this.layout.setState(state);
     }
+
+    /**
+     * Returns the root elements by delegating to the layout.
+     * @returns {HTMLElement[]} The root elements.
+     */
+    public get roots(): HTMLElement[] {
+        return this.layout.roots;
+    }
 }

--- a/src/main/ts/core/events/EventManager.ts
+++ b/src/main/ts/core/events/EventManager.ts
@@ -4,24 +4,23 @@ import { CustomEventTypes, DarkModeToggleEventDetail, LegacyEventTypes } from ".
 
 export class EventManager {
     private readonly element: HTMLElement;
-    private readonly roots: HTMLElement[];
+    private readonly roots: () => HTMLElement[];
 
-    constructor(element: HTMLElement, rootSelector: string) {
+    constructor(element: HTMLElement, roots: () => HTMLElement[]) {
         this.element = element;
-        this.roots = Array.from(
-            globalThis.document.querySelectorAll<HTMLElement>(
-                rootSelector
-            )
-        );
+        this.roots = roots;
     }
 
     /**
      * Dispatches the darkmode:change event on source and all root elements
+     * 
+     * Implementation note: roots() is called fresh on every dispatch to support dynamically
+     * added/removed root elements. Do NOT cache the result of roots().
      * @param state - The current state of the darkmode toggle
      */
     dispatch(state: DarkModeState) {
         EventManager.dispatchChangeEvent(this.element);
-        EventManager.dispatchDarkModeChangeEvent(state.isLight, state.theme, this.element, this.roots);
+        EventManager.dispatchDarkModeChangeEvent(state.isLight, state.theme, this.element, this.roots());
     }
 
     /**

--- a/src/test/ts/core/dom/AbstractLayout.test.ts
+++ b/src/test/ts/core/dom/AbstractLayout.test.ts
@@ -39,9 +39,11 @@ describe("AbstractLayout", () => {
     let root2: HTMLElement;
 
     beforeEach(() => {
+        jest.clearAllMocks();
+        document.body.innerHTML = "";
+        
         container = document.createElement("div");
         document.body.appendChild(container);
-        jest.clearAllMocks();
 
         root1 = document.createElement("div");
         root2 = document.createElement("div");
@@ -70,6 +72,28 @@ describe("AbstractLayout", () => {
 
             expect(container.innerHTML).not.toContain("old");
             expect(control).toBeInstanceOf(HTMLElement);
+        });
+    });
+
+    describe("roots", () => {
+        it("should return all root elements", () => {
+            const { builder } = createBuilder();
+
+            expect(builder.roots).toStrictEqual([root1, root2]);
+        });
+        
+        it("should re-query DOM each time (not cached)", () => {
+            const { builder } = createBuilder();
+            const firstCall = builder.roots;
+
+            const newRoot = document.createElement("div");
+            newRoot.className = "root";
+            document.body.appendChild(newRoot);
+
+            const secondCall = builder.roots;
+
+            expect(secondCall).not.toBe(firstCall);
+            expect(secondCall).toHaveLength(3);
         });
     });
 

--- a/src/test/ts/core/dom/DomManager.test.ts
+++ b/src/test/ts/core/dom/DomManager.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /// <reference types="jest" />
 import { DomManager } from "../../../../main/ts/core/dom/DomManager";
 import { Layout, ResolvedOptions, StorageType } from "../../../../main/ts/core/OptionResolver.types";
@@ -11,21 +12,21 @@ const mockOnChange: jest.Mock = jest.fn()
     .mockImplementation((handler) => {capturedHandler = handler;});
 const mockOnChangeHandler = jest.fn();
 
+const mockLayout: Partial<AbstractLayout> = {
+    setState: mockSetState,
+    onChange: mockOnChange,
+    roots: [document.createElement("div"), document.createElement("span")],
+};
+
 jest.mock("../../../../main/ts/core/dom/layouts/ButtonLayout", () => {
     return {
-        ButtonLayout: jest.fn().mockImplementation(() => ({
-            setState: mockSetState,
-            onChange: mockOnChange,
-        })),
+        ButtonLayout: jest.fn().mockImplementation(() => mockLayout),
     };
 });
 
 jest.mock("../../../../main/ts/core/dom/layouts/ToggleLayout", () => {
     return {
-        ToggleLayout: jest.fn().mockImplementation(() => ({
-            setState: mockSetState,
-            onChange: mockOnChange,
-        })),
+        ToggleLayout: jest.fn().mockImplementation(() => mockLayout),
     };
 });
 
@@ -62,6 +63,7 @@ describe("DomManager", () => {
     beforeEach(() => {
         jest.clearAllMocks();
         capturedHandler = () => {};
+        (mockLayout as any).roots = [document.createElement("div"), document.createElement("span")];
 
         element = document.createElement("div");
     });
@@ -90,6 +92,13 @@ describe("DomManager", () => {
             const domManager = createDomManager(layout);
             domManager.setState({isLight:true, theme:"light"});
             expect(mockSetState).toHaveBeenCalledWith({isLight:true, theme:"light"});
+        });
+    });
+
+    describe("roots", () => {
+        it.each(layouts)("should delegate roots on layout %s", (layout) => {
+            const domManager = createDomManager(layout);
+            expect(domManager.roots).toEqual(mockLayout.roots);
         });
     });
 

--- a/src/test/ts/core/events/EventManager.test.ts
+++ b/src/test/ts/core/events/EventManager.test.ts
@@ -8,35 +8,22 @@ let root: HTMLElement;
 
 const elementEventDispatchMock = jest.fn();
 const rootEventDispatchMock = jest.fn();
+const mockRootsFn = jest.fn(() => [root]);
 
 function createEventManager():EventManager{
-    return new EventManager(element, ".root");
+    return new EventManager(element, mockRootsFn);
 }
 
-describe("DomManager", () => {
+describe("EventManager", () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        document.body.innerHTML = "";
 
         element = document.createElement("div");
-        document.body.appendChild(element);
         jest.spyOn(element, "dispatchEvent").mockImplementation(elementEventDispatchMock);
 
         root = document.createElement("div");
         root.className = "root";
-        document.body.appendChild(root);
         jest.spyOn(root, "dispatchEvent").mockImplementation(rootEventDispatchMock);
-    });
-
-    describe("constructor", () => {
-        it("should get all roots", () => {
-            const root2 = document.createElement("div");
-            root2.className = "root";
-            document.body.appendChild(root2);
-
-            const instance = createEventManager();
-            expect((instance as any).roots).toStrictEqual([root, root2]);
-        });
     });
 
     describe("dispatch(state)", () => {
@@ -46,6 +33,12 @@ describe("DomManager", () => {
 
             expect(elementEventDispatchMock).toHaveBeenCalledTimes(2);
             expect(rootEventDispatchMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("should get all roots", () => {
+            const instance = createEventManager();
+            instance.dispatch({ isLight: true, theme: "light" });
+            expect(mockRootsFn).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation

### Description
**Provide a brief description of the change.**

Replaced static root selection with dynamic runtime queries. The previous implementation captured root elements only at construction time, missing any elements added or removed after initialization.

**Key changes:**
- `AbstractLayout`: `root` property replaced with `rootSelector` string; added `roots` getter that re-queries DOM on each access
- `DomManager`: added `roots` getter that delegates to `layout.roots`
- `EventManager`: changed from storing static root array to accepting a roots function, called fresh on each dispatch
- `DarkModeToggle`: reordered initialization to pass `dom.roots` function instead of static root selector string

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests.**
- [x] Added tests
- [ ] Modified tests
- [ ] Fixed tests
- [x] Removed tests (please explain why in additional notes)

**Tests added:**
- `AbstractLayout.test.ts`: roots getter tests (returns all root elements, re-queries DOM each time)
- `DomManager.test.ts`: roots delegation test
- `EventManager.test.ts`: roots function invocation test

**Tests removed:**
- `EventManager.test.ts`: constructor roots collection test (no longer relevant as roots are now dynamic)

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [ ] Documentation updated

### Additional Notes
**Provide any additional information or context.**

The implementation note in `EventManager.dispatch()` explicitly warns against caching the roots result to maintain dynamic behavior.

No issue number is referenced as this is a standalone refactor.

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide.
- [x] All tests are passing.
- [x] The pull request description is complete.
- [x] Documentation is updated if needed.