### PR TITLE
feat: implement destroy API for complete instance cleanup

### DIFF
--- a/cypress/e2e/methods/destroy.spec.cy.js
+++ b/cypress/e2e/methods/destroy.spec.cy.js
@@ -1,0 +1,58 @@
+/// <reference types="cypress" />
+
+import Interfaces from "../../support/Interfaces/interfaces.js";
+import DarkmodeToggleComponent from "../../support/page-objects/DarkmodeToggleComponent.js";
+import TestAppPage from "../../support/page-objects/TestAppPage.js";
+
+describe("API Destroy Method Feature", () => {
+    const data_test = "methods";
+
+    const cases = [
+        {
+            label: "dark",
+        },
+        {
+            label: "light",
+        },
+    ];
+
+    Interfaces.forEach((pluginInterface) => {
+        beforeEach(() => {
+            TestAppPage.visit(pluginInterface, data_test);
+        });
+
+        cases.forEach(({ label }) => {
+            context(`When Bootstrap Darkmode Toggle is in ${label} mode`, () => {
+                context("And destroy method is invoked", () => {
+                    const btn = "#destroy";
+
+                    function check($element, colorMode) {
+                        const checkRoot = ($root) => {
+                            cy.get($root)
+                                .should("have.attr", DarkmodeToggleComponent.BS_ATTRIBUTE)
+                                .and("eq", colorMode);
+                        };
+
+                        cy.get(btn)
+                            .click()
+                            .then(() => {
+                                cy.get($element).should("have.html", "");
+                                DarkmodeToggleComponent.getRoot($element)
+                                    .then(checkRoot);
+                            });
+                        
+                    }
+
+                    it(`Then control is destroyed but ${label} color scheme is preserved on container`, () => {
+                        TestAppPage.getTestContainers().each(($test) => {
+                            TestAppPage.getTestElement($test).each(($element) => {
+                                DarkmodeToggleComponent.invokeMethod($element, pluginInterface, label);
+                                check($element, label);                      
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/cypress/support/page-objects/DarkmodeToggleComponent.js
+++ b/cypress/support/page-objects/DarkmodeToggleComponent.js
@@ -167,26 +167,26 @@ class DarkmodeToggleComponent {
     }
 
     static setLight($element, pluginInterface, silent = true) {
-        this.#invokeMethod($element, pluginInterface, "light", silent);
+        this.invokeMethod($element, pluginInterface, "light", silent);
     }
 
     static setDark($element, pluginInterface, silent = true) {
-        this.#invokeMethod($element, pluginInterface, "dark", silent);
+        this.invokeMethod($element, pluginInterface, "dark", silent);
     }
 
     static toggle($element, pluginInterface, silent = true) {
-        this.#invokeMethod($element, pluginInterface, "toggle", silent);
+        this.invokeMethod($element, pluginInterface, "toggle", silent);
     }
 
     static allowCookie($element, pluginInterface) {
-        this.#invokeMethod($element, pluginInterface, "allowCookie");
+        this.invokeMethod($element, pluginInterface, "allowCookie");
     }
 
     static denyCookie($element, pluginInterface) {
-        this.#invokeMethod($element, pluginInterface, "denyCookie");
+        this.invokeMethod($element, pluginInterface, "denyCookie");
     }
 
-    static #invokeMethod($element, pluginInterface, method, silent) {
+    static invokeMethod($element, pluginInterface, method, silent) {
         const args = silent !== undefined ? [method, silent] : [method];
 
         if (pluginInterface === "ecmas") {

--- a/docs/src/js/components/documentation/api/Methods.js
+++ b/docs/src/js/components/documentation/api/Methods.js
@@ -4,7 +4,7 @@ class Methods extends DocArticle {
     static #methods = [
         {
             method: "initialize",
-            params: null,
+            params: [],
             description: "Initializes the plugin with options.",
         },
         {
@@ -27,6 +27,11 @@ class Methods extends DocArticle {
             params: ["set_storage", "none"],
             description: `Set the storage to use for user preferences.<br>
             <small class="text-muted">Provide <code>cache</code>, <code>local</code> or <code>none</code> as second argument.</small>`,
+        },
+        {
+            method: "destroy",
+            params: ["destroy"],
+            description: "Destroys the control, removes it from the DOM and clean the element reference.",
         },
     ];
 

--- a/src/main/js/index.jquery.js
+++ b/src/main/js/index.jquery.js
@@ -24,6 +24,9 @@ import { Methods } from "./types/Methods";
           case Methods.SET_STORAGE:
             _bsDarkmodeToggle.setStorageType(args);
             break;
+          case Methods.DESTROY:
+            _bsDarkmodeToggle.destroy();
+            break;
         }
       }
       this._bsDarkmodeToggle = _bsDarkmodeToggle;

--- a/src/main/ts/DarkModeToggle.ts
+++ b/src/main/ts/DarkModeToggle.ts
@@ -17,6 +17,8 @@ export class DarkModeToggle {
     private readonly dom: DomManager;
     private readonly eventManager: EventManager;
 
+    private _destroyed:boolean = false;
+
     constructor(element: HTMLElement, opts = {}) {
         this.element = element;
 
@@ -47,7 +49,6 @@ export class DarkModeToggle {
      * @private
      */
     private setupCrossInstanceSync(){
-        // TODO: Remove this event listener in destroy() method - see issue #64
         globalThis.document.addEventListener(CustomEventTypes.CHANGE, this.handleExternalThemeChange);
     }
 
@@ -80,24 +81,28 @@ export class DarkModeToggle {
     }
 
     toggle(silent = false) {
+        this.ensureNotDestroyed();
         if(!this.state.do(ActionType.TOGGLE)) return;
         this.syncState();
         this.trigger(silent);
     }
 
     light(silent = false) {
+        this.ensureNotDestroyed();
         if(!this.state.do(ActionType.LIGHT)) return;
         this.syncState();
         this.trigger(silent);
     }
 
     dark(silent = false) {
+        this.ensureNotDestroyed();
         if(!this.state.do(ActionType.DARK)) return;
         this.syncState();
         this.trigger(silent);
     }
 
     setStorageType(type: StorageType) {
+        this.ensureNotDestroyed();
         this.storage.setStorageType(type);
         this.persistTheme();
     }
@@ -185,5 +190,28 @@ export class DarkModeToggle {
             console.warn("Unable to detect system color scheme preference:", error);
             return ColorModes.NONE;
         }
+    }
+
+    /**
+     * Checks if the bs-darkmode-toggle instance has been destroyed.
+     * If it has, throws an error indicating that the instance is no longer usable.
+     * This is a safety measure to prevent accessing methods of a destroyed instance.
+     * @throws {Error} If the instance has been destroyed.
+     */
+    private ensureNotDestroyed(): void{
+        if (this._destroyed) throw new Error("Accessing to a method of a destroyed bs-darkmode-toggle instance.");
+    }
+
+    /**
+     * Destroys the dark mode toggle by removing the event listener, destroying the dom implementation and removing the reference to the toggle from the element.
+     * This method should be called when the dark mode toggle is no longer needed.
+     * @returns {void}
+     */
+    destroy(){
+        if(this._destroyed) return;
+        globalThis.document.removeEventListener(CustomEventTypes.CHANGE, this.handleExternalThemeChange);
+        this.dom.destroy();
+        delete this.element._bsDarkmodeToggle;
+        this._destroyed = true;
     }
 }

--- a/src/main/ts/core/dom/AbstractLayout.ts
+++ b/src/main/ts/core/dom/AbstractLayout.ts
@@ -68,4 +68,10 @@ export abstract class AbstractLayout {
      * @param {(e: Event) => void} handler - The callback handler to blink.
      */
     public abstract onChange(handler: (e: Event) => void): void;
+
+    /**
+     * Destroys the layout.
+     * @abstract This method must be overridden in subclasses.
+     */
+    public abstract destroy(): void;
 }

--- a/src/main/ts/core/dom/DomManager.ts
+++ b/src/main/ts/core/dom/DomManager.ts
@@ -48,4 +48,12 @@ export class DomManager{
     public get roots(): HTMLElement[] {
         return this.layout.roots;
     }
+
+    /**
+     * Destroys the layout by delegating to the layout implementation.
+     * This method should be called when the DomManager is no longer needed.
+     */
+    public destroy(): void {
+        this.layout.destroy();
+    }
 }

--- a/src/main/ts/core/dom/layouts/ButtonLayout.ts
+++ b/src/main/ts/core/dom/layouts/ButtonLayout.ts
@@ -3,6 +3,8 @@ import { AbstractLayout } from "../AbstractLayout";
 export class ButtonLayout extends AbstractLayout {
     private _button?: HTMLButtonElement;
 
+    private handler?: (e: Event) => void;
+
     /**
      * Creates the control element for the layout and appends it to the container.
      * @implements AbstractLayout
@@ -49,8 +51,18 @@ export class ButtonLayout extends AbstractLayout {
      * @param {(e: Event) => void} handler - The callback handler to blink
      */
     onChange(handler: (e: Event) => void): void {
-        this.button.addEventListener("click", (e) => {
-            handler(e);
-        });
+        this.handler = handler;
+        this.button.addEventListener("click", handler);
+    }
+
+    /**
+     * Destroys the layout.
+     * If a handler is attached, it will be detached first.
+     * Then, the button control element will be removed from the DOM.
+     */
+    destroy(): void {
+        if(this.handler) this.button.removeEventListener("click", this.handler);
+        this.handler = undefined;
+        this.button.remove();
     }
 }

--- a/src/main/ts/core/dom/layouts/ToggleLayout.ts
+++ b/src/main/ts/core/dom/layouts/ToggleLayout.ts
@@ -3,6 +3,7 @@ import { AbstractLayout } from "../AbstractLayout";
 
 export class ToggleLayout extends AbstractLayout {
     private _input?: BootstrapToggleElement;
+    private handler?: (e: Event) => void;
 
     /**
      * Create a Bootstrap Toggle control in the given container.
@@ -49,7 +50,18 @@ export class ToggleLayout extends AbstractLayout {
      * @param {(e: Event) => void} handler - The callback handler to blink
      */
     onChange(handler: (e: Event) => void) {
+        this.handler = handler;
         this.input.addEventListener("change", handler);
+    }
+
+    /**
+     * Destroys the layout and removes any event listeners attached to the control element.
+     */
+    destroy(): void {
+        if(this.handler) this.input.removeEventListener("change", this.handler);
+        this.handler = undefined;
+        this.input.bootstrapToggle(BootstrapToggleMethods.DESTROY);
+        this.input.remove();
     }
 }
 

--- a/src/main/ts/index.ecmas.ts
+++ b/src/main/ts/index.ecmas.ts
@@ -26,6 +26,9 @@ import { Methods } from "./types/Methods";
             case Methods.SET_STORAGE:
                 instance.setStorageType(args as StorageType);
                 break;
+            case Methods.DESTROY:
+                instance.destroy();
+                break;
             }
         }
     };

--- a/src/main/ts/types/Methods.ts
+++ b/src/main/ts/types/Methods.ts
@@ -3,4 +3,5 @@ export enum Methods {
   DARK = "DARK",
   TOGGLE = "TOGGLE",
   SET_STORAGE = "SET_STORAGE",
+  DESTROY = "DESTROY",
 }

--- a/src/test/ts/DarkModeToggle.test.ts
+++ b/src/test/ts/DarkModeToggle.test.ts
@@ -13,6 +13,7 @@ const setStateMock = jest.fn();
 
 const domManagerMock: Partial<DomManager> = {
     setState: setStateMock,
+    destroy: jest.fn(),
     roots: [],
 };
 
@@ -84,8 +85,10 @@ function setMatchMedia(colorMode: ColorModes) {
 }
 
 describe("DarkModeToggle", () => {
+    let instance: DarkModeToggle;
     let element: HTMLElement;
     let documentAddEventListenerSpy: jest.SpyInstance;
+    let documentRemoveEventListenerSpy: jest.SpyInstance;
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -100,19 +103,22 @@ describe("DarkModeToggle", () => {
 
         globalThis.window.matchMedia = matchMediaMock;
         documentAddEventListenerSpy = jest.spyOn(globalThis.document, "addEventListener");
+        documentRemoveEventListenerSpy = jest.spyOn(globalThis.document, "removeEventListener");
     });
 
     afterEach(() => {
+        instance?.destroy();
         for (const [eventName, listener] of documentAddEventListenerSpy.mock.calls) {
             globalThis.document.removeEventListener(eventName, listener);
         }
         documentAddEventListenerSpy.mockRestore();
+        documentRemoveEventListenerSpy.mockRestore();
     });
 
 
     describe("constructor", () => {
         it("should initialize and call update", () => {
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             expect(setStateMock).toHaveBeenCalledWith({ isLight: true, theme: "light" });
             expect(setStorageMock).toHaveBeenCalled();
@@ -120,7 +126,7 @@ describe("DarkModeToggle", () => {
         });
 
         it("should set up cross-instance synchronization listener", () => {
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             
             expect(documentAddEventListenerSpy).toHaveBeenCalledWith(
                 CustomEventTypes.CHANGE,
@@ -131,7 +137,7 @@ describe("DarkModeToggle", () => {
 
     describe("toggle(silent = false)", () => {
         it("should toggle and trigger event", () => {
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             instance.toggle();
 
@@ -142,7 +148,7 @@ describe("DarkModeToggle", () => {
 
         it("should NOT toggle if reducer returns false", () => {
             doMock.mockReturnValue(false);
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             instance.toggle();
 
@@ -151,18 +157,24 @@ describe("DarkModeToggle", () => {
         });
 
         it("should not trigger event when silent", () => {
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             instance.toggle(true);
 
             expect(setStateMock).toHaveBeenCalledTimes(2);
             expect(dispatchMock).not.toHaveBeenCalled();
         });
+
+        it("should throw error if destroyed", () => {
+            instance = new DarkModeToggle(element);
+            instance.destroy();
+            expect(() => instance.toggle()).toThrow("Accessing to a method of a destroyed bs-darkmode-toggle instance.");
+        });
     });
 
     describe("light(silent = false)", () => {
         it("should set light and trigger event", () => {
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             instance.light();
 
@@ -174,7 +186,7 @@ describe("DarkModeToggle", () => {
         it("should NOT set light if reducer returns false", () => {
             doMock.mockReturnValue(false);
 
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             instance.light();
 
@@ -183,18 +195,24 @@ describe("DarkModeToggle", () => {
         });
 
         it("should not trigger event when silent", () => {
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             instance.light(true);
 
             expect(setStateMock).toHaveBeenCalledTimes(2);
             expect(dispatchMock).not.toHaveBeenCalled();
         });
+
+        it("should throw error if destroyed", () => {
+            instance = new DarkModeToggle(element);
+            instance.destroy();
+            expect(() => instance.light()).toThrow("Accessing to a method of a destroyed bs-darkmode-toggle instance.");
+        });
     });
 
     describe("dark(silent = false)", () => {
         it("should set dark and trigger event", () => {
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             instance.dark();
 
@@ -206,7 +224,7 @@ describe("DarkModeToggle", () => {
         it("should NOT set dark if reducer returns false", () => {
             doMock.mockReturnValue(false);
 
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             instance.dark();
 
@@ -215,23 +233,35 @@ describe("DarkModeToggle", () => {
         });
 
         it("should not trigger event when silent", () => {
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             instance.dark(true);
 
             expect(setStateMock).toHaveBeenCalledTimes(2);
             expect(dispatchMock).not.toHaveBeenCalled();
         });
+
+        it("should throw error if destroyed", () => {
+            instance = new DarkModeToggle(element);
+            instance.destroy();
+            expect(() => instance.dark()).toThrow("Accessing to a method of a destroyed bs-darkmode-toggle instance.");
+        });
     });
   
     describe("setStorageType", () => {
         it("should change storage type and persist state", () => {
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             
             instance.setStorageType(StorageType.LOCAL);
             
             expect(setStorageTypeMock).toHaveBeenCalledWith(StorageType.LOCAL);
             expect(setStorageTypeMock).toHaveBeenCalled();
+        });
+
+        it("should throw error if destroyed", () => {
+            instance = new DarkModeToggle(element);
+            instance.destroy();
+            expect(() => instance.setStorageType(StorageType.LOCAL)).toThrow("Accessing to a method of a destroyed bs-darkmode-toggle instance.");
         });
     });
 
@@ -241,7 +271,7 @@ describe("DarkModeToggle", () => {
             
             setMatchMedia(ColorModes.LIGHT);
             
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             
             expect(doMock).toHaveBeenCalledWith(colorMode);
             expect(doMock).toHaveBeenCalledTimes(1);
@@ -252,7 +282,7 @@ describe("DarkModeToggle", () => {
             
             setMatchMedia(colorMode);
             
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             
             expect(doMock).toHaveBeenCalledWith(colorMode);
             expect(doMock).toHaveBeenCalledTimes(1);
@@ -263,7 +293,7 @@ describe("DarkModeToggle", () => {
             
             setMatchMedia(ColorModes.NONE);
             
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             
             expect(doMock).not.toHaveBeenCalled();
         });
@@ -273,7 +303,7 @@ describe("DarkModeToggle", () => {
         it.each([ColorModes.DARK, ColorModes.LIGHT])("should return the correct preference when system prefers %s", (expectedPreference) => {
             setMatchMedia(expectedPreference);
             
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             const result = (instance as any).getSystemPreference();
             
             expect(result).toBe(expectedPreference);
@@ -282,7 +312,7 @@ describe("DarkModeToggle", () => {
         it("should return null when matchMedia not available", () => {
             globalThis.window.matchMedia = undefined as any;
             
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             const result = (instance as any).getSystemPreference();
             
             expect(result).toBe(ColorModes.NONE);
@@ -291,7 +321,7 @@ describe("DarkModeToggle", () => {
         it("should return null when no preference detected", () => {
             setMatchMedia(ColorModes.NONE);
             
-            const instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             const result = (instance as any).getSystemPreference();
             
             expect(result).toBe(ColorModes.NONE);
@@ -329,7 +359,7 @@ describe("DarkModeToggle", () => {
 
         it("should update state and DOM when external event shares roots", () => {
             doMock.mockReturnValue(true);
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             setStateMock.mockClear();
             
             const event = new DarkModeToggleEvent(CustomEventTypes.CHANGE,
@@ -344,7 +374,7 @@ describe("DarkModeToggle", () => {
 
         it("should NOT update DOM when event state matches current state", () => {
             doMock.mockReturnValue(false);
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             setStateMock.mockClear();
             
             const event = new DarkModeToggleEvent(CustomEventTypes.CHANGE,
@@ -360,7 +390,7 @@ describe("DarkModeToggle", () => {
         it("should NOT update state and DOM when external event has no shared roots", () => {
             const differentRoot = document.createElement("div");
 
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
             
             setStateMock.mockClear();
             
@@ -375,7 +405,7 @@ describe("DarkModeToggle", () => {
         });
 
         it("should NOT update when event affects only a subset of roots", () => {
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             setStateMock.mockClear();
 
@@ -390,7 +420,7 @@ describe("DarkModeToggle", () => {
         });
 
         it("should not update storage or trigger events when external event is received", () => {
-            const _instance = new DarkModeToggle(element);
+            instance = new DarkModeToggle(element);
 
             setStorageMock.mockClear();
             dispatchMock.mockClear();
@@ -403,6 +433,42 @@ describe("DarkModeToggle", () => {
 
             expect(setStorageMock).toHaveBeenCalledTimes(0);
             expect(dispatchMock).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe("destroy", () => {
+        it("should remove event listeners", () => {
+            instance = new DarkModeToggle(element);
+            instance.destroy();
+            expect(documentAddEventListenerSpy).toHaveBeenCalledWith(
+                CustomEventTypes.CHANGE,
+                expect.any(Function)
+            );
+        });
+
+        it("should destroy DOM delegating to DomManager", () => {
+            instance = new DarkModeToggle(element);
+            instance.destroy();
+            expect(domManagerMock.destroy).toHaveBeenCalledTimes(1);
+        });
+
+        it("should remove reference to instance from element", () => {
+            instance = new DarkModeToggle(element);
+            instance.destroy();
+            expect((element as any)._bsDarkmodeToggle).toBeUndefined();
+        });
+
+        it("should set destroyed flag", () => {
+            instance = new DarkModeToggle(element);
+            instance.destroy();
+            expect((instance as any)._destroyed).toBe(true);
+        });
+
+        it("should not throw if already destroyed (idempotent)", () => {
+            instance = new DarkModeToggle(element);
+            instance.destroy();
+            expect(() => instance.destroy()).not.toThrow();
+            expect(domManagerMock.destroy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/test/ts/core/dom/AbstractLayout.test.ts
+++ b/src/test/ts/core/dom/AbstractLayout.test.ts
@@ -5,11 +5,13 @@ import { DarkModeState } from "../../../../main/ts/core/StateReducer.types";
 
 class ConcreteLayout extends AbstractLayout {
     public updateControlStateSpy: jest.Mock = jest.fn();
+    private control?: HTMLElement;
     
     protected createControl(container: HTMLElement): void {
         const div = document.createElement("div");
         div.id = "control";
         container.appendChild(div);
+        this.control = div;
     }
     
     protected updateControlState(state: DarkModeState): void {
@@ -18,6 +20,9 @@ class ConcreteLayout extends AbstractLayout {
     
     public onChange(_handler: (e: Event) => void): void {
         // Mock implementation
+    }
+    public destroy(): void {
+        if (this.control) this.control.remove();
     }
 }
 

--- a/src/test/ts/core/dom/DomManager.test.ts
+++ b/src/test/ts/core/dom/DomManager.test.ts
@@ -11,10 +11,12 @@ const mockSetState: jest.Mock = jest.fn();
 const mockOnChange: jest.Mock = jest.fn()
     .mockImplementation((handler) => {capturedHandler = handler;});
 const mockOnChangeHandler = jest.fn();
+const mockDestroy = jest.fn();
 
 const mockLayout: Partial<AbstractLayout> = {
     setState: mockSetState,
     onChange: mockOnChange,
+    destroy: mockDestroy,
     roots: [document.createElement("div"), document.createElement("span")],
 };
 
@@ -111,6 +113,14 @@ describe("DomManager", () => {
             
             expect(mockOnChangeHandler).toHaveBeenCalledTimes(1);
             expect(mockOnChangeHandler).toHaveBeenCalledWith(mockEvent);
+        });
+    });
+
+    describe("destroy", () => {
+        it.each(layouts)("should delegate destroy on layout %s", (layout) => {
+            const domManager = createDomManager(layout);
+            domManager.destroy();
+            expect(mockDestroy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/test/ts/core/dom/layouts/ButtonLayout.test.ts
+++ b/src/test/ts/core/dom/layouts/ButtonLayout.test.ts
@@ -146,4 +146,21 @@ describe("ButtonLayout", () => {
             expect(handler2).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe("destroy()", () => {
+        it("should remove control", () => {
+            const { builder, control } = createBuilder();
+            builder.destroy();
+            expect(container.contains(control)).toBeFalsy();
+        });
+
+        it("should remove event listeners", () => {
+            const { builder, control } = createBuilder();
+            const handler = jest.fn();
+            builder.onChange(handler);
+            builder.destroy();
+            control.dispatchEvent(new Event("click"));
+            expect(handler).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/src/test/ts/core/dom/layouts/ToggleLayout.test.ts
+++ b/src/test/ts/core/dom/layouts/ToggleLayout.test.ts
@@ -160,4 +160,22 @@ describe("ToggleLayout", () => {
             expect(handler2).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe("destroy()", () => {
+        it("should destroy toggle and remove control", () => {
+            const { builder, control } = createBuilder();
+            builder.destroy();
+            expect (bsToggleSpy).toHaveBeenCalledWith(BootstrapToggleMethods.DESTROY);
+            expect(container.contains(control)).toBeFalsy();
+        });
+
+        it("should remove event listeners", () => {
+            const { builder, control } = createBuilder();
+            const handler = jest.fn();
+            builder.onChange(handler);
+            builder.destroy();
+            control.dispatchEvent(new Event("change"));
+            expect(handler).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/test/loaders/MethodsLoader.js
+++ b/test/loaders/MethodsLoader.js
@@ -74,6 +74,12 @@ export class MethodsLoader extends BaseLoader {
                     $element[0].bsDarkmodeToggle("toggle", true),
             },
             {
+                id: "destroy",
+                text: "Destroy",
+                onClickJquery: () => $element.bsDarkmodeToggle("destroy"),
+                onClickEcmas: () => $element[0].bsDarkmodeToggle("destroy"),
+            },
+            {
                 id: "setProviderCookie",
                 text: "Set provider COOKIE",
                 onClickJquery: () => $element.bsDarkmodeToggle("set_storage", "cookie"),


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation

### Description
**Provide a brief description of the change.**
- Implements #64 — Adds a `destroy()` API method for complete plugin instance cleanup
- Enables proper disposal of DarkModeToggle instances in SPAs and dynamic applications
- Prevents memory leaks by removing event listeners and DOM elements

**Key changes:**
- New `destroy()` method on `DarkModeToggle` instance
- Removes global document event listener for cross-instance sync
- Cleans up layout-specific DOM (button or toggle input)
- Deletes `_bsDarkmodeToggle` reference from host element
- All public methods throw error when called on destroyed instance
- jQuery and ECMAScript wrappers expose `DESTROY` method
- Updated documentation API reference with destroy method

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests.**
- [x] Added tests
- [ ] Modified tests
- [ ] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

**Test additions:**
- Unit tests for `destroy()` method (idempotency, error throwing, cleanup chain)
- Unit tests for `ButtonLayout.destroy()` and `ToggleLayout.destroy()`
- E2E tests (`cypress/e2e/methods/destroy.spec.cy.js`) verifying container emptied but color scheme preserved
- Mock updates for `domManager.destroy()` in existing tests

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [x] Documentation updated

**Documentation updates:**
- Added destroy method to API Methods documentation (`docs/src/js/components/documentation/api/Methods.js`)
- JSDoc comments added for `destroy()` and `ensureNotDestroyed()` methods

### Additional Notes
**Provide any additional information or context.**

**Implementation decisions:**
- `destroy()` is idempotent — calling multiple times has no effect
- Destroyed instance throws `Error` on any method call (toggle, light, dark, setStorageType)
- Storage preferences are NOT cleared (persisted independently)
- `data-bs-theme` attributes on root elements remain unchanged (per spec)
- Bootstrap Toggle receives `"destroy"` command before element removal

**Breaking changes:** None — this is a new additive API.

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide.
- [x] All tests are passing.
- [x] The pull request description is complete.
- [x] Documentation is updated if needed.