### PR TITLE
feat: add configurable ARIA labels for accessibility

### DIFF
--- a/docs/src/js/components/documentation/Features.js
+++ b/docs/src/js/components/documentation/Features.js
@@ -1,4 +1,5 @@
 import DocSection from "./DocSection";
+import AriaLabel from "./features/AriaLabel";
 import State from "./features/State";
 import Root from "./features/Root";
 import Label from "./features/Label";
@@ -13,6 +14,7 @@ class Features extends DocSection {
             State.build(),
             Root.build(),
             Label.build(),
+            AriaLabel.build(),
             Style.build(),
             ColorScheme.build(),
             Layout.build(),

--- a/docs/src/js/components/documentation/api/Options.js
+++ b/docs/src/js/components/documentation/api/Options.js
@@ -30,7 +30,9 @@ class Options extends DocArticle {
           lightColorMode: "blue",
           darkColorMode: "red",
           style: "primary",
-          layout : "toggle"
+          layout : "toggle",
+          lightAriaLabel: "Custom aria label for light mode",
+          darkAriaLabel: "Custom aria label for dark mode",
         });
     });
 </script>`;
@@ -52,7 +54,9 @@ class Options extends DocArticle {
           lightColorMode: "blue",
           darkColorMode: "red",
           style: "primary",
-          layout : "toggle"
+          layout : "toggle",
+          lightAriaLabel: "Custom aria label for light mode",
+          darkAriaLabel: "Custom aria label for dark mode",
         });
     });
 </script>`;
@@ -90,7 +94,9 @@ class Options extends DocArticle {
                 lightColorMode: "blue",
                 darkColorMode: "red",
                 style: "primary",
-                layout : "toggle"
+                layout : "toggle",
+                lightAriaLabel: "Custom aria label for light mode",
+                darkAriaLabel: "Custom aria label for dark mode",
             });
         };
 
@@ -189,6 +195,20 @@ class Options extends DocArticle {
                 <td>string</td>
                 <td><code class="text-nowrap">"toggle"</code></td>
                 <td>Set the layout.<br>Possible values are: <code>toggle</code> and <code>button</code></td>
+            </tr>
+            <tr>
+                <td><code class="text-nowrap">lightAriaLabel</code></td>
+                <td><code class="text-nowrap">data-light-aria-label</code></td>
+                <td>string</td>
+                <td><code class="text-nowrap">"Switch to dark mode"</code></td>
+                <td>Set the ARIA label to display for the light mode.</td>>
+            </tr>
+            <tr>
+                <td><code class="text-nowrap">darkAriaLabel</code></td>
+                <td><code class="text-nowrap">data-dark-aria-label</code></td>
+                <td>string</td>
+                <td><code class="text-nowrap">"Switch to light mode"</code></td>
+                <td>Set the ARIA label to display for the dark mode.</td>>
             </tr>
         </tbody>
     </table>

--- a/docs/src/js/components/documentation/features/AriaLabel.js
+++ b/docs/src/js/components/documentation/features/AriaLabel.js
@@ -1,0 +1,51 @@
+import DocArticle from "../DocArticle";
+
+class AriaLabel {
+    static build() {
+        const code = `<div id="feature-aria-label-container" class="p-3 bg-body border">
+  <div data-plugin="bs-darkmode-toggle" data-light-aria-label="Custom Aria Light" data-dark-aria-label="Custom Aria Dark"></div>
+</div>`;
+
+        return DocArticle.build({
+            title: "Custom ARIA label",
+            description: AriaLabel.#description(),
+            example: AriaLabel.#example(),
+            codeBlock: {
+                language: "html",
+                code,
+            },
+            versionPill: {
+                version: "1.1.0",
+                action: "SINCE",
+            },
+        });
+    }
+
+    static #description() {
+        const description = document.createElement("div");
+
+        const paragraph = document.createElement("p");
+        paragraph.innerHTML = `Bootstrap Darkmode light and dark ARIA labels can be set by the <code>data-light-aria-label</code> and <code>data-dark-aria-label</code> attributes. These attributes accept HTML and strings as values.<br>
+<small class="text-muted">HTML is sanitized to prevent XSS attacks, however this may remove some HTML elements.</small>`;
+        description.append(paragraph);
+
+        return description;
+    }
+
+    static #example() {
+        const root = document.createElement("div");
+        root.id = "feature-aria-label-container";
+        root.className = "p-3 bg-body border";
+
+        const toggle = document.createElement("div");
+        toggle.dataset.plugin = "bs-darkmode-toggle";
+        toggle.id = "feature-aria-label-toggle";
+        toggle.dataset.root = "#feature-aria-label-container";
+        toggle.dataset.lightAriaLabel = "Custom Aria Light";
+        toggle.dataset.darkAriaLabel = "Custom Aria Dark";
+        root.appendChild(toggle);
+
+        return [root];
+    }
+}
+export default AriaLabel;

--- a/src/main/ts/core/OptionResolver.ts
+++ b/src/main/ts/core/OptionResolver.ts
@@ -11,7 +11,9 @@ export class OptionResolver {
         lightColorMode: "light",
         darkColorMode: "dark",
         style: "outline-secondary",
-        layout : Layout.TOGGLE
+        layout : Layout.TOGGLE,
+        lightAriaLabel: "Switch to dark mode",
+        darkAriaLabel: "Switch to light mode",
     };
 
     /**
@@ -37,6 +39,8 @@ export class OptionResolver {
             darkColorMode: sanitize(element.dataset.darkColorMode || options.darkColorMode || this.DEFAULTS.darkColorMode, { mode: SanitizeMode.TEXT })!,
             style: sanitize(element.dataset.style || options.style || this.DEFAULTS.style, { mode: SanitizeMode.TEXT }) as ToggleStyle,
             layout: sanitize(element.dataset.layout || options.layout || this.DEFAULTS.layout, { mode: SanitizeMode.TEXT }) as Layout,
+            lightAriaLabel: sanitize(element.dataset.lightAriaLabel || options.lightAriaLabel || this.DEFAULTS.lightAriaLabel, { mode: SanitizeMode.TEXT })!,
+            darkAriaLabel: sanitize(element.dataset.darkAriaLabel || options.darkAriaLabel || this.DEFAULTS.darkAriaLabel, { mode: SanitizeMode.TEXT })!,
         };
     }
 }

--- a/src/main/ts/core/OptionResolver.types.ts
+++ b/src/main/ts/core/OptionResolver.types.ts
@@ -8,6 +8,8 @@ export interface DarkModeOptions {
     darkColorMode?: string;
     style?: ToggleStyle;
     layout?: Layout;
+    lightAriaLabel?: string;
+    darkAriaLabel?: string;
 }
 
 export interface ResolvedOptions {
@@ -20,6 +22,8 @@ export interface ResolvedOptions {
     darkColorMode: string;
     style: ToggleStyle;
     layout: Layout;
+    lightAriaLabel: string;
+    darkAriaLabel: string;
 }
 
 export type ToggleStyle =

--- a/src/main/ts/core/dom/AbstractLayout.ts
+++ b/src/main/ts/core/dom/AbstractLayout.ts
@@ -6,6 +6,8 @@ export abstract class AbstractLayout {
     protected readonly lightLabel: string;
     protected readonly darkLabel: string;
     protected readonly style: string;
+    private readonly lightAriaLabel: string;
+    private readonly darkAriaLabel: string;
 
     protected static readonly BS_ATTRIBUTE = "bsTheme";
 
@@ -19,6 +21,8 @@ export abstract class AbstractLayout {
         this.lightLabel = options.lightLabel;
         this.darkLabel = options.darkLabel;
         this.style = options.style;
+        this.lightAriaLabel = options.lightAriaLabel;
+        this.darkAriaLabel = options.darkAriaLabel;
 
         container.innerHTML = "";
         this.createControl(container);
@@ -32,6 +36,15 @@ export abstract class AbstractLayout {
      */
     public get roots(): HTMLElement[] {
         return Array.from(globalThis.document.querySelectorAll<HTMLElement>(this.rootSelector));
+    }
+
+    /**
+     * Returns the aria label based on the given dark mode state.
+     * @param {boolean} isLight - The dark mode state.
+     * @returns {string} The aria label.
+     **/
+    protected getAriaLabel(isLight: boolean): string {
+        return isLight ? this.lightAriaLabel : this.darkAriaLabel;
     }
 
     /**

--- a/src/main/ts/core/dom/layouts/ButtonLayout.ts
+++ b/src/main/ts/core/dom/layouts/ButtonLayout.ts
@@ -35,6 +35,7 @@ export class ButtonLayout extends AbstractLayout {
     updateControlState({isLight}: DarkModeState): void {
         const label = isLight ? this.lightLabel : this.darkLabel;
         this.button.innerHTML = label;
+        this.button.ariaLabel = this.getAriaLabel(isLight);
         
         if (isLight) {
             this.button.classList.add("active");

--- a/src/main/ts/core/dom/layouts/ToggleLayout.ts
+++ b/src/main/ts/core/dom/layouts/ToggleLayout.ts
@@ -34,10 +34,17 @@ export class ToggleLayout extends AbstractLayout {
 
     /**
      * Update the state of the control element based on the given current state.
+     * 
+     * Implementation note: for performance reasons, rerender is only called if the ariaLabel has changed.
      * @implements AbstractLayout
      * @param {DarkModeState} state - The darkmode current state.
      */
     updateControlState({isLight}: DarkModeState) {
+        const newAriaLabel = this.getAriaLabel(isLight);
+        if (newAriaLabel !== this.input.ariaLabel) {
+            this.input.ariaLabel = newAriaLabel;
+            this.input.bootstrapToggle(BootstrapToggleMethods.RENDERER);
+        }
         this.input.bootstrapToggle(
             isLight ? BootstrapToggleMethods.ON : BootstrapToggleMethods.OFF,
             true

--- a/src/test/ts/DarkModeToggle.test.ts
+++ b/src/test/ts/DarkModeToggle.test.ts
@@ -3,11 +3,12 @@
 import { DarkModeToggle } from "../../main/ts/DarkModeToggle";
 import { ActionType } from "../../main/ts/core/StateReducer.types";
 import { OptionResolver } from "../../main/ts/core/OptionResolver";
-import { Layout, ResolvedOptions, StorageType } from "../../main/ts/core/OptionResolver.types";
+import { StorageType } from "../../main/ts/core/OptionResolver.types";
 import { ColorModes } from "../../main/ts/types/ColorModes";
 import { CustomEventTypes } from "../../main/ts/core/events/Events.types";
 import { DarkModeToggleEvent } from "../../main/ts/core/events/DarkModeToggleEvent";
 import { DomManager } from "../../main/ts/core/dom/DomManager";
+import { TestUtils } from "../utils/TestUtils";
 
 const setStateMock = jest.fn();
 
@@ -23,19 +24,7 @@ jest.mock("../../main/ts/core/dom/DomManager", () => {
     };
 });
 
-const baseOptions: ResolvedOptions = {
-    state: true,
-    root: ":root",
-    storage: StorageType.NONE,
-    lightLabel: "Light",
-    darkLabel: "Dark",
-    lightColorMode: "light",
-    darkColorMode: "dark",
-    style: "outline-secondary",
-    layout: Layout.TOGGLE,
-};
-
-const resolveMock = jest.spyOn(OptionResolver, "resolve").mockReturnValue({ ...baseOptions });
+const resolveMock = jest.spyOn(OptionResolver, "resolve").mockReturnValue({ ...TestUtils.baseOptions });
 
 const doMock = jest.fn();
 const getMock = jest.fn();
@@ -96,7 +85,7 @@ describe("DarkModeToggle", () => {
 
         element = document.createElement("div");
 
-        resolveMock.mockReturnValue({ ...baseOptions });
+        resolveMock.mockReturnValue({ ...TestUtils.baseOptions });
 
         getMock.mockReturnValue({ isLight: true, theme: "light" });
         doMock.mockReturnValue(true);

--- a/src/test/ts/core/OptionResolver.test.ts
+++ b/src/test/ts/core/OptionResolver.test.ts
@@ -205,4 +205,36 @@ describe("OptionResolver", () => {
             expect(result.layout).toBe(Layout.TOGGLE);
         });
     });
+
+    describe("Aria Label resolution", () => {
+        it("should resolve Aria Label from attributes", () => {
+            element.dataset.lightAriaLabel = "custom-light";
+            element.dataset.darkAriaLabel = "custom-dark";
+
+            const result = OptionResolver.resolve(element);
+
+            expect(result.lightAriaLabel).toBe("custom-light");
+            expect(sanitizeSpy).toHaveBeenCalledWith("custom-light", { mode: "TEXT" });
+
+            expect(result.darkAriaLabel).toBe("custom-dark");
+            expect(sanitizeSpy).toHaveBeenCalledWith("custom-dark", { mode: "TEXT" });
+        });
+
+        it("should resolve Aria Label from options", () => {
+            const result = OptionResolver.resolve(element, {
+                lightAriaLabel: "custom-light",
+                darkAriaLabel: "custom-dark",
+            });
+
+            expect(result.lightAriaLabel).toBe("custom-light");
+            expect(result.darkAriaLabel).toBe("custom-dark");
+        });
+
+        it("should fallback Aria Label to defaults", () => {
+            const result = OptionResolver.resolve(element);
+
+            expect(result.lightAriaLabel).toBe("Switch to dark mode");
+            expect(result.darkAriaLabel).toBe("Switch to light mode");
+        });
+    });
 });

--- a/src/test/ts/core/dom/AbstractLayout.test.ts
+++ b/src/test/ts/core/dom/AbstractLayout.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 import { AbstractLayout } from "../../../../main/ts/core/dom/AbstractLayout";
-import { ResolvedOptions, StorageType, Layout } from "../../../../main/ts/core/OptionResolver.types";
 import { DarkModeState } from "../../../../main/ts/core/StateReducer.types";
+import { TestUtils } from "../../../utils/TestUtils";
 
 class ConcreteLayout extends AbstractLayout {
     public updateControlStateSpy: jest.Mock = jest.fn();
@@ -25,18 +25,6 @@ class ConcreteLayout extends AbstractLayout {
         if (this.control) this.control.remove();
     }
 }
-
-const options: ResolvedOptions = {
-    state: true,
-    root: ".root",
-    storage: StorageType.NONE,
-    lightLabel: "Light",
-    darkLabel: "Dark",
-    lightColorMode: "light",
-    darkColorMode: "dark",
-    style: "outline-secondary",
-    layout: Layout.TOGGLE,
-};
 
 describe("AbstractLayout", () => {
     let container: HTMLElement;
@@ -62,7 +50,7 @@ describe("AbstractLayout", () => {
     });
 
     function createBuilder() {
-        const builder = new ConcreteLayout(container, options);
+        const builder = new ConcreteLayout(container, {...TestUtils.baseOptions, root: ".root"});
 
         const control = container.querySelector("#control") as HTMLElement;
 

--- a/src/test/ts/core/dom/DomManager.test.ts
+++ b/src/test/ts/core/dom/DomManager.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /// <reference types="jest" />
 import { DomManager } from "../../../../main/ts/core/dom/DomManager";
-import { Layout, ResolvedOptions, StorageType } from "../../../../main/ts/core/OptionResolver.types";
+import { Layout } from "../../../../main/ts/core/OptionResolver.types";
 import { AbstractLayout } from "../../../../main/ts/core/dom/AbstractLayout";
 import { ButtonLayout } from "../../../../main/ts/core/dom/layouts/ButtonLayout";
 import { ToggleLayout } from "../../../../main/ts/core/dom/layouts/ToggleLayout";
+import { TestUtils } from "../../../utils/TestUtils";
 
 let capturedHandler: (e: Event) => void;
 const mockSetState: jest.Mock = jest.fn();
@@ -45,20 +46,9 @@ function layoutResolver(layout: Layout):typeof AbstractLayout{
 }
 
 let element: HTMLElement;
-const baseOptions: ResolvedOptions = {
-    state: true,
-    root: ".root",
-    storage: StorageType.NONE,
-    lightLabel: "Light",
-    darkLabel: "Dark",
-    lightColorMode: "light",
-    darkColorMode: "dark",
-    style: "outline-secondary",
-    layout: Layout.TOGGLE,
-};
 
 function createDomManager(layout:Layout):DomManager{
-    return new DomManager(element,{...baseOptions, layout: layout}, mockOnChangeHandler);
+    return new DomManager(element,{...TestUtils.baseOptions, layout: layout}, mockOnChangeHandler);
 }
 
 describe("DomManager", () => {

--- a/src/test/ts/core/dom/layouts/ButtonLayout.test.ts
+++ b/src/test/ts/core/dom/layouts/ButtonLayout.test.ts
@@ -1,17 +1,8 @@
 import { ButtonLayout} from "../../../../../main/ts/core/dom/layouts/ButtonLayout";
-import { Layout, ResolvedOptions, StorageType } from "../../../../../main/ts/core/OptionResolver.types";
+import { Layout, ResolvedOptions } from "../../../../../main/ts/core/OptionResolver.types";
+import { TestUtils } from "../../../../utils/TestUtils";
 
-const options: ResolvedOptions = {
-    state: true,
-    root: ".root",
-    storage: StorageType.NONE,
-    lightLabel: "Light",
-    darkLabel: "Dark",
-    lightColorMode: "light",
-    darkColorMode: "dark",
-    style: "outline-secondary",
-    layout: Layout.BUTTON,
-};
+const options: ResolvedOptions = {...TestUtils.baseOptions, root: ".root", layout: Layout.BUTTON};
 
 describe("ButtonLayout", () => {
     let container: HTMLElement;
@@ -64,10 +55,18 @@ describe("ButtonLayout", () => {
             builder.setState({isLight: true, theme: "light"});
 
             expect(control.className).toContain("active");
-            expect(control.ariaPressed).toBe("true");
 
             expect(root1.dataset.bsTheme).toBe("light");
             expect(root2.dataset.bsTheme).toBe("light");
+        });
+
+        it("should set ARIA attributes when light mode is set", () => {
+            const { builder, control } = createBuilder();
+
+            builder.setState({isLight: true, theme: "light"});
+
+            expect(control.ariaPressed).toBe("true");
+            expect(control.ariaLabel).toBe(options.lightAriaLabel);
         });
 
         it("should set dark mode", () => {
@@ -76,10 +75,18 @@ describe("ButtonLayout", () => {
             builder.setState({isLight: false, theme: "dark"});
 
             expect(control.className).not.toContain("active");
-            expect(control.ariaPressed).toBe("false");
 
             expect(root1.dataset.bsTheme).toBe("dark");
             expect(root2.dataset.bsTheme).toBe("dark");
+        });
+
+        it("should set ARIA attributes when dark mode is set", () => {
+            const { builder, control } = createBuilder();
+
+            builder.setState({isLight: false, theme: "dark"});
+
+            expect(control.ariaPressed).toBe("false");
+            expect(control.ariaLabel).toBe(options.darkAriaLabel);
         });
 
         it("should update all root elements", () => {

--- a/src/test/ts/core/dom/layouts/ToggleLayout.test.ts
+++ b/src/test/ts/core/dom/layouts/ToggleLayout.test.ts
@@ -1,22 +1,14 @@
+/// <reference types="jest" />
 import { ToggleLayout, BootstrapToggleElement, BootstrapToggleMethods} from "../../../../../main/ts/core/dom/layouts/ToggleLayout";
-import { Layout, ResolvedOptions, StorageType } from "../../../../../main/ts/core/OptionResolver.types";
+import { Layout, ResolvedOptions } from "../../../../../main/ts/core/OptionResolver.types";
+import { TestUtils } from "../../../../utils/TestUtils";
 
 Object.defineProperty(HTMLInputElement.prototype, "bootstrapToggle", {
     value: jest.fn(),
     writable: true,
 });
 
-const options: ResolvedOptions = {
-    state: true,
-    root: ".root",
-    storage: StorageType.NONE,
-    lightLabel: "Light",
-    darkLabel: "Dark",
-    lightColorMode: "light",
-    darkColorMode: "dark",
-    style: "outline-secondary",
-    layout: Layout.TOGGLE,
-};
+const options: ResolvedOptions = {...TestUtils.baseOptions, root: ".root", layout: Layout.TOGGLE};
 
 describe("ToggleLayout", () => {
     const bsToggleSpy = jest.spyOn(HTMLInputElement.prototype as BootstrapToggleElement, "bootstrapToggle").mockImplementation(() => {});
@@ -84,6 +76,15 @@ describe("ToggleLayout", () => {
             expect(root2.dataset.bsTheme).toBe("light");
         });
 
+        it("should set ARIA attributes and rerender when light mode is sets", () => {
+            const { builder, control } = createBuilder();
+
+            builder.setState({isLight: true, theme: "light"});
+            
+            expect(control.ariaLabel).toBe(options.lightAriaLabel);
+            expect(bsToggleSpy).toHaveBeenCalledWith(BootstrapToggleMethods.RENDERER);
+        });
+
         it("should set dark mode", () => {
             const { builder } = createBuilder();
 
@@ -95,6 +96,15 @@ describe("ToggleLayout", () => {
             expect(root2.dataset.bsTheme).toBe("dark");
         });
 
+        it("should set ARIA attributes and rerender when dark mode is sets", () => {
+            const { builder, control } = createBuilder();
+
+            builder.setState({isLight: false, theme: "dark"});
+            
+            expect(control.ariaLabel).toBe(options.darkAriaLabel);
+            expect(bsToggleSpy).toHaveBeenCalledWith(BootstrapToggleMethods.RENDERER);
+        });
+
         it("should update all root elements", () => {
             const { builder } = createBuilder();
 
@@ -103,6 +113,16 @@ describe("ToggleLayout", () => {
             globalThis.document.querySelectorAll<HTMLElement>(".root").forEach((el) => {
                 expect(el.dataset.bsTheme).toBe("light");
             });
+        });
+
+        it("should not rerender Bootstrap Toggle if ariaLabel hasn't changed", () => {
+            const { builder } = createBuilder();
+
+            builder.setState({isLight: false, theme: "dark"});
+            bsToggleSpy.mockClear();
+            builder.setState({isLight: false, theme: "dark"});
+
+            expect(bsToggleSpy).not.toHaveBeenCalledWith(BootstrapToggleMethods.RENDERER);
         });
     });
 

--- a/src/test/utils/TestUtils.ts
+++ b/src/test/utils/TestUtils.ts
@@ -1,0 +1,24 @@
+import { Layout, ResolvedOptions, StorageType } from "../../main/ts/core/OptionResolver.types";
+
+export class TestUtils{
+
+    /**
+     * Gets the base options that are used when no options are provided.
+     * @returns {ResolvedOptions} The base options.
+     */
+    static get baseOptions():ResolvedOptions{
+        return {
+            state: true,
+            root: ":root",
+            storage: StorageType.NONE,
+            lightLabel: "Light",
+            darkLabel: "Dark",
+            lightColorMode: "light",
+            darkColorMode: "dark",
+            style: "outline-secondary",
+            layout: Layout.TOGGLE,
+            lightAriaLabel: "Switch to dark mode",
+            darkAriaLabel: "Switch to light mode",
+        };
+    }
+}


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation

### Description
**Provide a brief description of the change.**

This PR adds configurable ARIA labels to improve accessibility for screen readers and assistive technologies.

- Adds `lightAriaLabel` and `darkAriaLabel` options with defaults
  "Switch to dark mode" and "Switch to light mode"
- ARIA labels dynamically update when theme changes to describe the
  action that will be performed (e.g., when in light mode, label
  says "Switch to dark mode")
- Supports configuration via JavaScript options or HTML data
  attributes (`data-light-aria-label`, `data-dark-aria-label`)
- ButtonLayout updates `aria-label` directly
- ToggleLayout updates `aria-label` and calls `rerender` only when
  label changes for performance

Implements #65

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests.**
- [x] Added tests
- [ ] Modified tests
- [ ] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [x] Documentation updated

### Additional Notes
**Provide any additional information or context.**

- Added `TestUtils.baseOptions` to reduce test duplication
- ToggleLayout performance optimization: only calls `RENDERER` when
  `aria-label` actually changes
- Default labels follow WCAG guidance: describe the action that
  will occur when activated

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide.
- [x] All tests are passing.
- [x] The pull request description is complete.
- [x] Documentation is updated if needed.