### PR TITLE
fix: use official Methods.RERENDER from bootstrap5-toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@types/jquery": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
-    "bootstrap5-toggle": "^5.0.0",
+    "bootstrap5-toggle": "^5.3.3",
     "commitlint": "^20.3.1",
     "cypress": "^15.8.1",
     "cypress-plugin-tab": "^2.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,40 +3,49 @@ import terser from "@rollup/plugin-terser";
 export default [
     {
         input: "src/main/js/index.ecmas.js",
+        external: ["bootstrap5-toggle"],
         output: [
             {
                 file: "js/bs-darkmode-toggle.ecmas.js",
                 format: "umd",
-                sourcemap: true
+                sourcemap: true,
+                globals: {
+                    "bootstrap5-toggle": "BootstrapToggle"
+                }
             },
             {
                 file: "js/bs-darkmode-toggle.ecmas.min.js",
                 format: "umd",
                 sourcemap: true,
-                plugins: [terser()]
+                plugins: [terser()],
+                globals: {
+                    "bootstrap5-toggle": "BootstrapToggle"
+                }
             }
         ]
     },
     {
         input: "src/main/js/index.jquery.js",
-        external: ["jquery"],
+        external: ["bootstrap5-toggle", "jquery"],
         output: [
             {
                 file: "js/bs-darkmode-toggle.jquery.js",
                 format: "umd",
                 sourcemap: true,
                 globals: {
+                    "bootstrap5-toggle": "BootstrapToggle",
                     jquery: "jQuery"
-                }
+                },
             },
             {
                 file: "js/bs-darkmode-toggle.jquery.min.js",
                 format: "umd",
                 sourcemap: true,
                 globals: {
+                    "bootstrap5-toggle": "BootstrapToggle",
                     jquery: "jQuery"
                 },
-                plugins: [terser()]
+                plugins: [terser()],
             }
         ]
     }

--- a/src/main/ts/core/dom/layouts/ToggleLayout.ts
+++ b/src/main/ts/core/dom/layouts/ToggleLayout.ts
@@ -1,3 +1,4 @@
+import { BootstrapToggleElement, Methods } from "bootstrap5-toggle";
 import { DarkModeState } from "../../StateReducer.types";
 import { AbstractLayout } from "../AbstractLayout";
 
@@ -43,10 +44,10 @@ export class ToggleLayout extends AbstractLayout {
         const newAriaLabel = this.getAriaLabel(isLight);
         if (newAriaLabel !== this.input.ariaLabel) {
             this.input.ariaLabel = newAriaLabel;
-            this.input.bootstrapToggle(BootstrapToggleMethods.RENDERER);
+            this.input.bootstrapToggle(Methods.RERENDER);
         }
         this.input.bootstrapToggle(
-            isLight ? BootstrapToggleMethods.ON : BootstrapToggleMethods.OFF,
+            isLight ? Methods.ON : Methods.OFF,
             true
         );
     }
@@ -67,27 +68,7 @@ export class ToggleLayout extends AbstractLayout {
     destroy(): void {
         if(this.handler) this.input.removeEventListener("change", this.handler);
         this.handler = undefined;
-        this.input.bootstrapToggle(BootstrapToggleMethods.DESTROY);
+        this.input.bootstrapToggle(Methods.DESTROY);
         this.input.remove();
     }
-}
-
-export interface BootstrapToggleElement extends HTMLInputElement {
-  bootstrapToggle(
-    options?: BootstrapToggleMethods | Record<string, unknown>,
-    silent?: boolean
-  ): void;
-}
-
-export enum BootstrapToggleMethods {
-  ON = "ON",
-  OFF = "OFF",
-  TOGGLE = "TOGGLE",
-  DETERMINATE = "DETERMINATE",
-  INDETERMINATE = "INDETERMINATE",
-  ENABLE = "ENABLE",
-  DISABLE = "DISABLE",
-  READONLY = "READONLY",
-  DESTROY = "DESTROY",
-  RENDERER = "RENDERER",
 }

--- a/src/test/ts/core/dom/layouts/ToggleLayout.test.ts
+++ b/src/test/ts/core/dom/layouts/ToggleLayout.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="jest" />
-import { ToggleLayout, BootstrapToggleElement, BootstrapToggleMethods} from "../../../../../main/ts/core/dom/layouts/ToggleLayout";
+import { BootstrapToggleElement, Methods } from "bootstrap5-toggle";
+import { ToggleLayout } from "../../../../../main/ts/core/dom/layouts/ToggleLayout";
 import { Layout, ResolvedOptions } from "../../../../../main/ts/core/OptionResolver.types";
 import { TestUtils } from "../../../../utils/TestUtils";
 
@@ -70,7 +71,7 @@ describe("ToggleLayout", () => {
 
             builder.setState({isLight: true, theme: "light"});
 
-            expect(bsToggleSpy).toHaveBeenCalledWith(BootstrapToggleMethods.ON, true);
+            expect(bsToggleSpy).toHaveBeenCalledWith(Methods.ON, true);
 
             expect(root1.dataset.bsTheme).toBe("light");
             expect(root2.dataset.bsTheme).toBe("light");
@@ -82,7 +83,7 @@ describe("ToggleLayout", () => {
             builder.setState({isLight: true, theme: "light"});
             
             expect(control.ariaLabel).toBe(options.lightAriaLabel);
-            expect(bsToggleSpy).toHaveBeenCalledWith(BootstrapToggleMethods.RENDERER);
+            expect(bsToggleSpy).toHaveBeenCalledWith(Methods.RERENDER);
         });
 
         it("should set dark mode", () => {
@@ -90,7 +91,7 @@ describe("ToggleLayout", () => {
 
             builder.setState({isLight: false, theme: "dark"});
 
-            expect(bsToggleSpy).toHaveBeenCalledWith(BootstrapToggleMethods.OFF, true);
+            expect(bsToggleSpy).toHaveBeenCalledWith(Methods.OFF, true);
 
             expect(root1.dataset.bsTheme).toBe("dark");
             expect(root2.dataset.bsTheme).toBe("dark");
@@ -102,7 +103,7 @@ describe("ToggleLayout", () => {
             builder.setState({isLight: false, theme: "dark"});
             
             expect(control.ariaLabel).toBe(options.darkAriaLabel);
-            expect(bsToggleSpy).toHaveBeenCalledWith(BootstrapToggleMethods.RENDERER);
+            expect(bsToggleSpy).toHaveBeenCalledWith(Methods.RERENDER);
         });
 
         it("should update all root elements", () => {
@@ -122,7 +123,7 @@ describe("ToggleLayout", () => {
             bsToggleSpy.mockClear();
             builder.setState({isLight: false, theme: "dark"});
 
-            expect(bsToggleSpy).not.toHaveBeenCalledWith(BootstrapToggleMethods.RENDERER);
+            expect(bsToggleSpy).not.toHaveBeenCalledWith(Methods.RERENDER);
         });
     });
 
@@ -185,7 +186,7 @@ describe("ToggleLayout", () => {
         it("should destroy toggle and remove control", () => {
             const { builder, control } = createBuilder();
             builder.destroy();
-            expect (bsToggleSpy).toHaveBeenCalledWith(BootstrapToggleMethods.DESTROY);
+            expect (bsToggleSpy).toHaveBeenCalledWith(Methods.DESTROY);
             expect(container.contains(control)).toBeFalsy();
         });
 


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation

### Description
**Provide a brief description of the change.**
- Fixes #89: ToggleLayout uses RENDERER method due to bootstrap5-toggle naming inconsistency
- Replaced local `BootstrapToggleMethods.RENDERER` (uppercase) with `Methods.RERENDER` from the external `bootstrap5-toggle` package
- Upgraded `bootstrap5-toggle` from `^5.0.0` to `^5.3.3`
- Updated `rollup.config.js` to properly externalize the dependency with global name `'BootstrapToggle'`, resolving runtime module resolution issues

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests.**
- [ ] Added tests
- [x] Modified tests
- [ ] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [ ] Documentation updated

### Additional Notes
**Provide any additional information or context.**
- Unit tests were modified to import `Methods` from the external package instead of the removed local `BootstrapToggleMethods` enum
- All 257 unit tests and 60 E2E tests pass
- This change was blocked by palcarazm/bootstrap5-toggle#313 (upstream naming inconsistency); the upgrade to `bootstrap5-toggle@5.3.3` includes the fix

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide.
- [x] All tests are passing.
- [x] The pull request description is complete.
- [ ] Documentation is updated if needed.